### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.2
 smbus2==0.4.1
 opencv-python==4.6.0.66
-rpi.gpio==0.7.0
+rpi.gpio==0.7.1


### PR DESCRIPTION
Raspberry Pi 5でpipコマンドを実行する際に、エラーが出ないようにするため、rpi.gpioのバージョンを新しくしました。Raspberry Piの他のVer.（Pi 4、Pi 3B+）においても、問題無いことを確認済です