### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ google-api-python-client==2.33.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.2
 smbus2==0.4.1
-opencv-python==4.6.0.66
 rpi.gpio==0.7.1


### PR DESCRIPTION
Raspberry Pi 5への対応のため、opencvインストールのための1行を削除しました。Pi 5でopencvをpipでインストールしようとするとエラーがでるため、atpでインストールしています（aptでのインストールはreadmeに反映しました）。